### PR TITLE
Remove uses of Spree.t and Spree.translate

### DIFF
--- a/app/models/spree/product_package.rb
+++ b/app/models/spree/product_package.rb
@@ -4,7 +4,7 @@ module Spree
 
     validates :length, :width, :height, :weight,
               :numericality => { :only_integer => true,
-                                 :message => Spree.t('validation.must_be_int'),
+                                 :message => I18n.t('spree.validation.must_be_int'),
                                  :greater_than => 0 }
   end
 end

--- a/app/overrides/spree/admin/shared/_configuration_menu/add_active_shipping_settings_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_configuration_menu/add_active_shipping_settings_tab.html.erb.deface
@@ -1,3 +1,3 @@
 <!-- insert_bottom "[data-hook='admin_configurations_sidebar_menu'], #admin_configurations_sidebar_menu[data-hook]" -->
 
-<%= configurations_sidebar_menu_item Spree.t(:active_shipping_settings), edit_admin_active_shipping_settings_path %>
+<%= configurations_sidebar_menu_item I18n.t("spree.active_shipping_settings"), edit_admin_active_shipping_settings_path %>

--- a/app/overrides/spree/admin/shared/_product_tabs/add_product_packages_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_product_packages_tab.html.erb.deface
@@ -2,6 +2,6 @@
 
 <% if can? :update, @product.product_packages.build %>
   <li<%== ' class=\"active\"' if current == 'Product Packages' %>>
-    <%= link_to_with_icon 'cube', Spree.t(:product_packages), admin_product_product_packages_url(@product) %>
+    <%= link_to_with_icon 'cube', I18n.t("spree.product_packages"), admin_product_product_packages_url(@product) %>
   </li>
 <% end %>

--- a/app/views/spree/admin/active_shipping_settings/edit.html.erb
+++ b/app/views/spree/admin/active_shipping_settings/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-<%= Spree.t(:active_shipping_settings) %>
+<%= I18n.t("spree.active_shipping_settings") %>
 <% end %>
 
 <%= form_tag admin_active_shipping_settings_path, :method => :put  do |form| %>
@@ -10,26 +10,26 @@
     <div class="row">
       <div class="alpha six columns">
         <fieldset class="security no-border-bottom">
-          <legend align="center"><%= Spree.t(:ups_settings)%></legend>
+          <legend align="center"><%= I18n.t("spree.ups_settings")%></legend>
           <% @preferences_UPS.each do |key|
             type = @config.preference_type(key) %>
             <div class="field">
-              <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+              <%= label_tag(key, I18n.t("spree.#{key}") + ': ') + tag(:br) if type != :boolean %>
               <%= preference_field_tag(key, @config[key], :type => type) %>
-              <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+              <%= label_tag(key, I18n.t("spree.#{key}")) + tag(:br) if type == :boolean %>
             </div>
             <% end %>
           </fieldset>
         </div>
         <div class="omega six columns">
           <fieldset class="currency no-border-bottom">
-            <legend align="center"><%= Spree.t(:fedex_settings)%></legend>
+            <legend align="center"><%= I18n.t("spree.fedex_settings")%></legend>
             <% @preferences_FedEx.each do |key|
               type = @config.preference_type(key) %>
               <div class="field">
-                <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                <%= label_tag(key, I18n.t("spree.#{key}") + ': ') + tag(:br) if type != :boolean %>
                 <%= preference_field_tag(key, @config[key], :type => type) %>
-                <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+                <%= label_tag(key, I18n.t("spree.#{key}")) + tag(:br) if type == :boolean %>
               </div>
               <% end %>
             </fieldset>
@@ -39,26 +39,26 @@
         <div class="row">
           <div class="alpha six columns">
             <fieldset class="security no-border-bottom">
-              <legend align="center"><%= Spree.t(:usps_settings)%></legend>
+              <legend align="center"><%= I18n.t("spree.usps_settings")%></legend>
               <% @preferences_USPS.each do |key|
                 type = @config.preference_type(key) %>
                 <div class="field">
-                  <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                  <%= label_tag(key, I18n.t("spree.#{key}") + ': ') + tag(:br) if type != :boolean %>
                   <%= preference_field_tag(key, @config[key], :type => type) %>
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+                  <%= label_tag(key, I18n.t("spree.#{key}")) + tag(:br) if type == :boolean %>
                 </div>
                 <% end %>
               </fieldset>
             </div>
             <div class="omega six columns">
               <fieldset class="currency no-border-bottom">
-                <legend align="center"><%= Spree.t(:canada_post_settings)%></legend>
+                <legend align="center"><%= I18n.t("spree.canada_post_settings")%></legend>
                 <% @preferences_CanadaPost.each do |key|
                   type = @config.preference_type(key) %>
                   <div class="field">
-                    <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                    <%= label_tag(key, I18n.t("spree.#{key}") + ': ') + tag(:br) if type != :boolean %>
                     <%= preference_field_tag(key, @config[key], :type => type) %>
-                    <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+                    <%= label_tag(key, I18n.t("spree.#{key}")) + tag(:br) if type == :boolean %>
                   </div>
                   <% end %>
                 </fieldset>
@@ -68,13 +68,13 @@
             <div class="row">
               <div class="omega six columns">
                 <fieldset class="currency no-border-bottom">
-                  <legend align="center"><%= Spree.t(:canada_post_settings)%></legend>
+                  <legend align="center"><%= I18n.t("spree.canada_post_settings")%></legend>
                   <% @preferences_CanadaPostPws.each do |key|
                     type = @config.preference_type(key) %>
                     <div class="field">
-                      <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                      <%= label_tag(key, I18n.t("spree.#{key}") + ': ') + tag(:br) if type != :boolean %>
                       <%= preference_field_tag(key, @config[key], :type => type) %>
-                      <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+                      <%= label_tag(key, I18n.t("spree.#{key}")) + tag(:br) if type == :boolean %>
                     </div>
                     <% end %>
                   </fieldset>
@@ -82,13 +82,13 @@
 
                 <div class="alpha six columns">
                   <fieldset class="currency no-border-bottom">
-                    <legend align="center"><%= Spree.t(:general_settings)%></legend>
+                    <legend align="center"><%= I18n.t("spree.general_settings")%></legend>
                     <% @preferences_GeneralSettings.each do |key|
                       type = @config.preference_type(key) %>
                       <div class="field">
-                        <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
+                        <%= label_tag(key, I18n.t("spree.#{key}") + ': ') + tag(:br) if type != :boolean %>
                         <%= preference_field_tag(key, @config[key], :type => type) %>
-                        <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+                        <%= label_tag(key, I18n.t("spree.#{key}")) + tag(:br) if type == :boolean %>
                       </div>
                       <% end %>
                     </fieldset>
@@ -96,9 +96,9 @@
                 </div>
 
                 <div class="form-buttons filter-actions actions" data-hook="buttons">
-                  <%= button Spree.t(:update), 'icon-refresh' %>
-                  <span class="or"><%= Spree.t(:or) %></span>
-                  <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), edit_admin_active_shipping_settings_url, :class => 'button' %>
+                  <%= button I18n.t("spree.update"), 'icon-refresh' %>
+                  <span class="or"><%= I18n.t("spree.or") %></span>
+                  <%= link_to_with_icon 'icon-remove', I18n.t("spree.cancel"), edit_admin_active_shipping_settings_url, :class => 'button' %>
                 </div>
 
               </fieldset>

--- a/app/views/spree/admin/box_slots/_form.html.erb
+++ b/app/views/spree/admin/box_slots/_form.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="column four">
     <div data-hook="height" class="field">
-      <%= f.label Spree.t(:default) %><br>
+      <%= f.label I18n.t("spree.default") %><br>
       <%= f.check_box :default, class: "checkbox" %>
     </div>
   </div>

--- a/app/views/spree/admin/box_slots/edit.html.erb
+++ b/app/views/spree/admin/box_slots/edit.html.erb
@@ -1,12 +1,12 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-    <%= Spree.t(:editing_box_slot) %>
+    <%= I18n.t("spree.editing_box_slot") %>
 <% end %>
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to Spree.t(:back_to_box_slots_list), spree.admin_box_slots_path, :icon => 'arrow-left' %>
+      <%= button_link_to I18n.t("spree.back_to_box_slots_list"), spree.admin_box_slots_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/box_slots/index.html.erb
+++ b/app/views/spree/admin/box_slots/index.html.erb
@@ -1,16 +1,16 @@
 <%= render :partial => 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-    <%= Spree.t(:listing_box_slots) %>
+    <%= I18n.t("spree.listing_box_slots") %>
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to Spree.t(:new_box_slot), new_admin_box_slot_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_slot_link'} %>
+    <%= button_link_to I18n.t("spree.new_box_slot"), new_admin_box_slot_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_slot_link'} %>
 <% end %>
 
 <% unless @box_slots.any? %>
     <div class="no-objects-found">
-      <%= Spree.t(:no_box_slots_found) %>.
+      <%= I18n.t("spree.no_box_slots_found") %>.
     </div>
 <% else %>
     <table class="table">
@@ -21,8 +21,8 @@
       </colgroup>
       <thead data-hook="option_header">
         <tr data-hook="product_packages_header">
-          <th><%= Spree.t(:label) %></th>
-          <th><%= Spree.t(:default) %></th>
+          <th><%= I18n.t("spree.label") %></th>
+          <th><%= I18n.t("spree.default") %></th>
           <th class="actions"></th>
         </tr>
       </thead>

--- a/app/views/spree/admin/box_slots/new.html.erb
+++ b/app/views/spree/admin/box_slots/new.html.erb
@@ -1,12 +1,12 @@
 <%= render :partial => 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-    <%= Spree.t(:new_box_slot) %>
+    <%= I18n.t("spree.new_box_slot") %>
 <% end %>
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to Spree.t(:back_to_box_slots_list), spree.admin_box_slots_path, :icon => 'arrow-left' %>
+      <%= button_link_to I18n.t("spree.back_to_box_slots_list"), spree.admin_box_slots_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/boxes/_form.html.erb
+++ b/app/views/spree/admin/boxes/_form.html.erb
@@ -8,7 +8,7 @@
     </div>
     <div class="columns four">
       <div data-hook="height" class="field">
-        <%= f.label Spree.t(:slots) %><br>
+        <%= f.label I18n.t("spree.slots") %><br>
         <%= f.number_field :slots, class: "form-control" %>
       </div>
     </div>
@@ -22,25 +22,25 @@
   <div class="row">
     <div class="alpha three columns">
       <div data-hook="length" class="field">
-        <%= f.label Spree.t(:unit_weight, unit: 'oz') %><br>
+        <%= f.label I18n.t("spree.unit_weight", unit: 'oz') %><br>
         <%= f.number_field :weight, step: :any, class: "form-control"  %>
       </div>
     </div>
     <div class="three columns">
       <div data-hook="length" class="field">
-        <%= f.label Spree.t(:unit_height, unit: 'in') %><br>
+        <%= f.label I18n.t("spree.unit_height", unit: 'in') %><br>
         <%= f.number_field :height, step: :any, class: "form-control"  %>
       </div>
     </div>
     <div class="three columns">
       <div data-hook="length" class="field">
-        <%= f.label Spree.t(:unit_width, unit: 'in') %><br>
+        <%= f.label I18n.t("spree.unit_width", unit: 'in') %><br>
         <%= f.number_field :width, step: :any, class: "form-control"  %>
       </div>
     </div>
     <div class="three columns">
       <div data-hook="length" class="field">
-        <%= f.label Spree.t(:unit_length, unit: 'in') %><br>
+        <%= f.label I18n.t("spree.unit_length", unit: 'in') %><br>
         <%= f.number_field :length, step: :any, class: "form-control"  %>
       </div>
     </div>

--- a/app/views/spree/admin/boxes/edit.html.erb
+++ b/app/views/spree/admin/boxes/edit.html.erb
@@ -1,12 +1,12 @@
 <%= render 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-    <%= Spree.t(:editing_box) %>
+    <%= I18n.t("spree.editing_box") %>
 <% end %>
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to Spree.t(:back_to_boxes_list), spree.admin_boxes_path, :icon => 'arrow-left' %>
+      <%= button_link_to I18n.t("spree.back_to_boxes_list"), spree.admin_boxes_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/boxes/index.html.erb
+++ b/app/views/spree/admin/boxes/index.html.erb
@@ -1,16 +1,16 @@
 <%= render :partial => 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-    <%= Spree.t(:listing_boxes) %>
+    <%= I18n.t("spree.listing_boxes") %>
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to Spree.t(:new_box), new_admin_box_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_link'} %>
+    <%= button_link_to I18n.t("spree.new_box"), new_admin_box_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_link'} %>
 <% end %>
 
 <% unless @boxes.any? %>
     <div class="no-objects-found">
-      <%= Spree.t(:no_boxes_found) %>.
+      <%= I18n.t("spree.no_boxes_found") %>.
     </div>
 <% else %>
     <table class="table">
@@ -21,8 +21,8 @@
       </colgroup>
       <thead data-hook="option_header">
         <tr data-hook="product_boxes_header">
-          <th><%= Spree.t(:slots) %></th>
-          <th><%= Spree.t(:box_slot) %></th>
+          <th><%= I18n.t("spree.slots") %></th>
+          <th><%= I18n.t("spree.box_slot") %></th>
           <th class="actions"></th>
         </tr>
       </thead>

--- a/app/views/spree/admin/boxes/new.html.erb
+++ b/app/views/spree/admin/boxes/new.html.erb
@@ -1,12 +1,12 @@
 <%= render :partial => 'spree/admin/shared/shipping_tabs' %>
 
 <% content_for :page_title do %>
-    <%= Spree.t(:new_box) %>
+    <%= I18n.t("spree.new_box") %>
 <% end %>
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to Spree.t(:back_to_boxes_list), spree.admin_boxes_path, :icon => 'arrow-left' %>
+      <%= button_link_to I18n.t("spree.back_to_boxes_list"), spree.admin_boxes_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/product_packages/_form.html.erb
+++ b/app/views/spree/admin/product_packages/_form.html.erb
@@ -1,21 +1,21 @@
 <div data-hook="admin_product_package_form_fields">
   <div class="six columns alpha">
     <div data-hook="length" class="field">
-      <%= f.label Spree.t(:length) %><br>
+      <%= f.label I18n.t("spree.length") %><br>
       <%= f.text_field :length %>
     </div>
     <div data-hook="width" class="field">
-      <%= f.label Spree.t(:width) %><br>
+      <%= f.label I18n.t("spree.width") %><br>
       <%= f.text_field :width %>
     </div>
   </div>
     <div class="six columns omega">
     <div data-hook="height" class="field">
-      <%= f.label Spree.t(:height) %><br>
+      <%= f.label I18n.t("spree.height") %><br>
       <%= f.text_field :height %>
     </div>
     <div data-hook="weight" class="field">
-      <%= f.label Spree.t(:weight) %><br>
+      <%= f.label I18n.t("spree.weight") %><br>
       <%= f.text_field :weight %>
     </div>
   </div>

--- a/app/views/spree/admin/product_packages/edit.html.erb
+++ b/app/views/spree/admin/product_packages/edit.html.erb
@@ -1,13 +1,13 @@
 <%= form_for [:admin, @product, @product_package], :html => { :multipart => true } do |f| %>
   <fieldset data-hook="edit_product_package">
-    <legend align="center"><%= Spree.t(:edit_package) %></legend>
+    <legend align="center"><%= I18n.t("spree.edit_package") %></legend>
 
       <%= render :partial => 'form', :locals => { :f => f } %>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'icon-refresh' %>
+        <%= button I18n.t("spree.update"), 'icon-refresh' %>
         <span class="or"><%= t(:or) %></span>
-        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), admin_product_product_packages_url(@product), :id => 'cancel_link', :class => 'button' %>
+        <%= link_to_with_icon 'icon-remove', I18n.t("spree.cancel"), admin_product_product_packages_url(@product), :id => 'cancel_link', :class => 'button' %>
       </div>
   </fieldset>
 <% end %>

--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon('icon-plus', Spree.t(:new_package), new_admin_product_product_package_url(@product), :id => 'new_product_package_link', :class => 'button') %></li>
+  <li><%= link_to_with_icon('icon-plus', I18n.t("spree.new_package"), new_admin_product_product_package_url(@product), :id => 'new_product_package_link', :class => 'button') %></li>
 <% end %>
 
 <% content_for :head do %>
@@ -14,16 +14,16 @@
 
 <% unless @product.reload.product_packages.any? %>
   <div class="no-objects-found">
-    <%= Spree.t(:no_packages_found) %>.
+    <%= I18n.t("spree.no_packages_found") %>.
   </div>
 <% else %>
   <table class="index">
     <thead data-hook="option_header">
       <tr data-hook="product_packages_header">
-        <th><%= Spree.t(:length) %></th>
-        <th><%= Spree.t(:width) %></th>
-        <th><%= Spree.t(:height) %></th>
-        <th><%= Spree.t(:weight) %></th>
+        <th><%= I18n.t("spree.length") %></th>
+        <th><%= I18n.t("spree.width") %></th>
+        <th><%= I18n.t("spree.height") %></th>
+        <th><%= I18n.t("spree.weight") %></th>
         <th class="actions"></th>
       </tr>
     </thead>
@@ -35,7 +35,7 @@
           <td><%= package.height %></td>
           <td><%= package.weight %></td>
           <td class="actions">
-            <%= link_to_with_icon 'icon-edit', Spree.t(:edit), edit_admin_product_product_package_url(@product, package), :class => "edit", :no_text => true, :data => {:action => 'edit'} %>
+            <%= link_to_with_icon 'icon-edit', I18n.t("spree.edit"), edit_admin_product_product_package_url(@product, package), :class => "edit", :no_text => true, :data => {:action => 'edit'} %>
             &nbsp;
             <%= link_to_delete package, { :url => admin_product_product_package_url(@product, package), :no_text => true }%>
           </td>

--- a/app/views/spree/admin/product_packages/new.html.erb
+++ b/app/views/spree/admin/product_packages/new.html.erb
@@ -1,13 +1,13 @@
 <%= form_for [:admin, @product, @product_package], :html => { :multipart => true } do |f| %>
   <fieldset data-hook="new_product_package">
-    <legend align="center"><%= Spree.t(:new_package) %></legend>
+    <legend align="center"><%= I18n.t("spree.new_package") %></legend>
 
       <%= render :partial => 'form', :locals => { :f => f } %>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t(:update), 'icon-refresh' %>
+        <%= button I18n.t("spree.update"), 'icon-refresh' %>
         <span class="or"><%= t(:or) %></span>
-        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), admin_product_product_packages_url(@product), :id => 'cancel_link', :class => 'button' %>
+        <%= link_to_with_icon 'icon-remove', I18n.t("spree.cancel"), admin_product_product_packages_url(@product), :id => 'cancel_link', :class => 'button' %>
       </div>
   </fieldset>
 <% end %>


### PR DESCRIPTION
Spree.t and Spree.translate are deprecated in solidus 3 and should be replaced with I18n.t