### PR TITLE
Fix the Boxes and Box Slots pages

### DIFF
--- a/app/views/spree/admin/box_slots/edit.html.erb
+++ b/app/views/spree/admin/box_slots/edit.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to I18n.t("spree.back_to_box_slots_list"), spree.admin_box_slots_path, :icon => 'arrow-left' %>
+      <%= button_to I18n.t("spree.back_to_box_slots_list"), spree.admin_box_slots_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/box_slots/index.html.erb
+++ b/app/views/spree/admin/box_slots/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to I18n.t("spree.new_box_slot"), new_admin_box_slot_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_slot_link'} %>
+    <%= button_to I18n.t("spree.new_box_slot"), new_admin_box_slot_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_slot_link'} %>
 <% end %>
 
 <% unless @box_slots.any? %>

--- a/app/views/spree/admin/boxes/index.html.erb
+++ b/app/views/spree/admin/boxes/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% content_for :page_actions do %>
-    <%= button_link_to I18n.t("spree.new_box"), new_admin_box_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_link'} %>
+    <%= button_to I18n.t("spree.new_box"), new_admin_box_url, {:class => "btn-success", :icon => 'add', :id => 'new_box_link'} %>
 <% end %>
 
 <% unless @boxes.any? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,3 +103,12 @@ en:
     default_weight: 'Default Weight'
     handling_fee: 'Handling Fee'
     max_weight_per_package: 'Max Weight Per Package'
+    back_to_box_slots_list: "Back to Box Slots List"
+    box_slot: "Box Slot"
+    editing_box_slot: "Editing Box Slot"
+    label: "Label"
+    listing_box_slots: "Listing Box Slots"
+    listing_boxes: "Listing Boxes"
+    new_box: "New Box"
+    new_box_slot: "New Box Slot"
+    slots: "Slots"


### PR DESCRIPTION
These were using `button_link_to` which errors. We should use `button_to` instead. I tested all these changes locally by updating the files in my vendor bundle in Personal Wine.

Once this got the pages loading, I noticed a bunch of missing translations too.

**Screenshots:** 
Boxes page (w/o translation fixes)
|Before  | After |
| ------------- | ------------- |
|<img width="1230" alt="Screenshot 2024-01-22 at 8 46 30 AM" src="https://github.com/pervino/solidus_active_shipping/assets/26180285/bde657e4-8946-46d2-963f-eea80166aae1">| <img width="1775" alt="Screenshot 2024-01-22 at 8 46 51 AM" src="https://github.com/pervino/solidus_active_shipping/assets/26180285/1bf782d8-9dcb-4153-9a4b-a8b2b8144bac">|

Boxes page final:
<img width="1781" alt="Screenshot 2024-01-22 at 8 57 04 AM" src="https://github.com/pervino/solidus_active_shipping/assets/26180285/12f174e1-7087-4944-aaa8-4a6693ae0b68">

Box Slots page final:
<img width="1781" alt="Screenshot 2024-01-22 at 8 59 34 AM" src="https://github.com/pervino/solidus_active_shipping/assets/26180285/54798e1a-4315-4c7d-847d-225654a0b73b">

