### PR TITLE
Fix editing a box

### DIFF
--- a/app/views/spree/admin/boxes/edit.html.erb
+++ b/app/views/spree/admin/boxes/edit.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to I18n.t("spree.back_to_boxes_list"), spree.admin_boxes_path, :icon => 'arrow-left' %>
+      <%= button_to I18n.t("spree.back_to_boxes_list"), spree.admin_boxes_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,8 +103,10 @@ en:
     default_weight: 'Default Weight'
     handling_fee: 'Handling Fee'
     max_weight_per_package: 'Max Weight Per Package'
+    back_to_boxes_list: "Back to Boxes List"
     back_to_box_slots_list: "Back to Box Slots List"
     box_slot: "Box Slot"
+    editing_box: "Editing Box"
     editing_box_slot: "Editing Box Slot"
     label: "Label"
     listing_box_slots: "Listing Box Slots"


### PR DESCRIPTION
This was erroring due to an old deprecated method, `button_link_to`

Before & After
![Screenshot 2024-01-23 at 8 43 59 AM](https://github.com/pervino/solidus_active_shipping/assets/26180285/8e5268b6-8b21-47b3-b50e-b9bff4ec8976)
![Screenshot 2024-01-23 at 8 45 31 AM](https://github.com/pervino/solidus_active_shipping/assets/26180285/889874e1-7fc2-44fa-b695-968d61529b55)
